### PR TITLE
Feature/config flow translations

### DIFF
--- a/custom_components/tempo/config_flow.py
+++ b/custom_components/tempo/config_flow.py
@@ -28,13 +28,13 @@ class TempoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Étape initiale de configuration."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
         if user_input is not None:
             return self.async_create_entry(title="EDF Tempo", data={})
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({}),
-            description_placeholders={
-                "description": "Cette intégration récupère les couleurs Tempo depuis l'API RTE et crée une entité unique avec tous les états."
-            },
         )

--- a/custom_components/tempo/config_flow.py
+++ b/custom_components/tempo/config_flow.py
@@ -17,7 +17,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.core import callback
 
 DOMAIN = "tempo"
 

--- a/custom_components/tempo/translations/de.json
+++ b/custom_components/tempo/translations/de.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+      "step": {
+        "user": {
+          "title": "EDF Tempo",
+          "description": "Diese Integration ruft die EDF‑Tempo‑Tariffarben über die RTE‑API ab und erstellt eine einzelne Entität mit allen Zuständen."
+        }
+      },
+      "abort": {
+        "already_configured": "EDF Tempo ist bereits konfiguriert."
+      }
+    }
+  }

--- a/custom_components/tempo/translations/en.json
+++ b/custom_components/tempo/translations/en.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "EDF Tempo",
+        "description": "This integration retrieves EDF Tempo tariff colors from the RTE API and creates a single entity with all states."
+      }
+    },
+    "abort": {
+      "already_configured": "EDF Tempo is already configured."
+    }
+  }
+}

--- a/custom_components/tempo/translations/fr.json
+++ b/custom_components/tempo/translations/fr.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+      "step": {
+        "user": {
+          "title": "EDF Tempo",
+          "description": "Cette intégration récupère les couleurs Tempo depuis l'API de RTE et crée une entité unique avec tous les états."
+        }
+      },
+      "abort": {
+        "already_configured": "EDF Tempo est déjà configuré."
+      }
+    }
+  }


### PR DESCRIPTION
## Résumé

Lors de l’ajout de l’intégration EDF Tempo via l’interface de Home Assistant
(version 2026.1, interface configurée en langue autre que français), la boîte de dialogue de
configuration était complètement vide et n’affichait qu’un bouton « OK ».

Ce comportement était dû au fait que le flux de configuration utilisait un
schéma vide et qu’aucune traduction n’était fournie pour ce flux. Dans ce cas,
Home Assistant affiche un dialogue vide.

Cette PR ajoute les traductions nécessaires pour le flux de configuration et
aligne celui‑ci sur les conventions de Home Assistant.

## Changements

- Ajout de `translations/en.json` 
- Ajout de `translations/fr.json` 
- Ajout de `translations/de.json`
- Mise à jour de `config_flow.py` :
  - Empêche la création de plusieurs instances de l’intégration en utilisant
    `async_abort` avec la raison `already_configured`.
  - Conserve un schéma minimal (vide) puisqu’aucune option n’est nécessaire,
    et laisse Home Assistant afficher le titre et la description traduits.

## Tests

Étapes réalisées :

1. Clonage de ce dépôt en local.
2. Application des modifications ci‑dessus.
3. Copie du dossier `custom_components/tempo` mis à jour dans la configuration
   de Home Assistant.
4. Redémarrage de Home Assistant (2026.1)
5. Menu **Paramètres → Appareils & Services → Ajouter une intégration** puis
   sélection de **EDF Tempo**.

**Avant cette PR :**

- La boîte de dialogue de configuration était totalement vide avec uniquement
  un bouton « OK ».

**Après cette PR :**

- La boîte de dialogue affiche :
  - le titre : `EDF Tempo`
  - une description localisée
- La soumission du formulaire crée correctement l’entrée d’intégration.
- Si une instance existe déjà, Home Assistant interrompt le flux avec le
  message `already_configured`.